### PR TITLE
bugfix: reopening closed channel

### DIFF
--- a/closer.go
+++ b/closer.go
@@ -223,6 +223,7 @@ func Init(cfg Config) {
 	c.codeErr = cfg.ExitCodeErr
 	c.signals = cfg.ExitSignals
 	signal.Notify(c.signalChan, c.signals...)
+	c.cancelWaitChan = make(chan struct{})
 	go c.wait()
 	c.sem.Unlock()
 }


### PR DESCRIPTION
The Init function closes the cancelWaitChan channel but doesn't reopen it, so the wait function always returns immediately with no effect after Init function was called.